### PR TITLE
tests: Make the server version check more forgiving

### DIFF
--- a/test/kria/server_test.clj
+++ b/test/kria/server_test.clj
@@ -27,5 +27,5 @@
       (let [[asc e a] @p]
         (is (nil? e))
         (is (= "riak@127.0.0.1" (:node a)))
-        (is (= "2.0.0" (:server-version a))))
+        (is (.startsWith (:server-version a) "2.0")))
       (c/disconnect conn))))


### PR DESCRIPTION
Instead of requiring the server to have the exact version number of 2.0.0, allow anything that starts with 2.0. This makes the test suite work with Riak 2.0.1.
