### PR TITLE
kria.bucket: Simplify the (call) invocation

### DIFF
--- a/src/clojure/kria/bucket.clj
+++ b/src/clojure/kria/bucket.clj
@@ -33,4 +33,4 @@
   (call asc cb :list-keys-req :list-keys-resp
         ListKeysReq->bytes bytes->ListKeysResp
         (merge opts {:bucket b})
-        true #(:keys %) #(:done %) stream-cb))
+        true :keys :done stream-cb))


### PR DESCRIPTION
Keywords can act as functions that look themselves up in their arguments, therefore `#(:keys %)` is the same as `:keys` alone, in a function context. With this in mind, the `(call)` invocation in `kria.bucket` can be simplified.

Noticed when running `lein kibit`.
