### PR TITLE
update clojure to 1.7.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.7.0-beta2"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [com.google.protobuf/protobuf-java "2.6.1"]
                  [com.basho.riak.protobuf/riak-pb "2.0.0.16"]]
   :source-paths ["src/clojure"]


### PR DESCRIPTION
Sure, 1.8 is out, but let's not get crazy here. Tests pass.