### PR TITLE
Secondary index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /target
 /classes
 /checkouts

--- a/README.md
+++ b/README.md
@@ -156,7 +156,10 @@ This section is intended for developers who want to run the included tests
 with `lein test`.
 
 1. Since the tests use Riak Search, please ensure that search
-   is enabled. Check that your `riak.conf` file has `search = on`.
+   is enabled. Check that your `riak.conf` file has `search = on`. If you
+   would like to test secondary indexes (2i), ensure that `storage_backend`
+   is set to `leveldb` or `memory`, ex. `storage_backend = leveldb`. Run tests
+   with `KRIA_TEST_2I=true` to test 2i.
 
 2. Also, run `test/riak-setup.sh` as root *once*, to create and activate the
    necessary bucket types.

--- a/src/clojure/kria/index.clj
+++ b/src/clojure/kria/index.clj
@@ -3,9 +3,9 @@
   (:require
    [kria.conversions :refer [byte-string?]]
    [kria.core :refer [call]]
-   [kria.pb.index.delete :refer [IndexDeleteReq->bytes]]
-   [kria.pb.index.get :refer [IndexGetReq->bytes bytes->IndexGetResp]]
-   [kria.pb.index.put :refer [IndexPutReq->bytes]]))
+   [kria.pb.index.yz.delete :refer [IndexDeleteReq->bytes]]
+   [kria.pb.index.yz.get :refer [IndexGetReq->bytes bytes->IndexGetResp]]
+   [kria.pb.index.yz.put :refer [IndexPutReq->bytes]]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/clojure/kria/index.clj
+++ b/src/clojure/kria/index.clj
@@ -35,10 +35,8 @@
         (assoc-in opts [:index :name] name)))
 
 
-;; Experimental 2i
-
 (defn get-2i
-  "Gets a secondary index"
+  "Gets a secondary index by equality (first arity) or range (second arity)"
   ([asc b k v opts cb]
    {:pre [(byte-string? b) (byte-string? k) (byte-string? v) (map? opts)]}
    (call asc cb :index-req :index-resp

--- a/src/clojure/kria/index.clj
+++ b/src/clojure/kria/index.clj
@@ -39,20 +39,22 @@
 
 (defn get-2i
   "Gets a secondary index"
-  ([asc b k v cb]
-   {:pre [(byte-string? b) (byte-string? k) (byte-string? v)]}
+  ([asc b k v opts cb]
+   {:pre [(byte-string? b) (byte-string? k) (byte-string? v) (map? opts)]}
    (call asc cb :index-req :index-resp
          IndexReq->bytes bytes->IndexResp
-         {:bucket b
-          :index k
-          :key v
-          :qtype :eq}))
-  ([asc b k v1 v2 cb]
-   {:pre [(byte-string? b) (byte-string? k) (byte-string? v1) (byte-string? v2)]}
+         (merge opts
+                {:bucket b
+                 :index k
+                 :key v
+                 :qtype :eq})))
+  ([asc b k v1 v2 opts cb]
+   {:pre [(byte-string? b) (byte-string? k) (byte-string? v1) (byte-string? v2) (map? opts)]}
    (call asc cb :index-req :index-resp
          IndexReq->bytes bytes->IndexResp
-         {:bucket b
-          :index k
-          :range-min v1
-          :range-max v2
-          :qtype :range})))
+         (merge opts
+                {:bucket b
+                 :index k
+                 :range-min v1
+                 :range-max v2
+                 :qtype :range}))))

--- a/src/clojure/kria/index.clj
+++ b/src/clojure/kria/index.clj
@@ -5,7 +5,8 @@
    [kria.core :refer [call]]
    [kria.pb.index.yz.delete :refer [IndexDeleteReq->bytes]]
    [kria.pb.index.yz.get :refer [IndexGetReq->bytes bytes->IndexGetResp]]
-   [kria.pb.index.yz.put :refer [IndexPutReq->bytes]]))
+   [kria.pb.index.yz.put :refer [IndexPutReq->bytes]]
+   [kria.pb.index.secondary.get :refer [IndexReq->bytes bytes->IndexResp]]))
 
 (set! *warn-on-reflection* true)
 
@@ -32,3 +33,26 @@
   (call asc cb :yz-index-put-req :yz-index-put-resp
         IndexPutReq->bytes (fn [_] true)
         (assoc-in opts [:index :name] name)))
+
+
+;; Experimental 2i
+
+(defn get-2i
+  "Gets a secondary index"
+  ([asc b k v cb]
+   {:pre [(byte-string? b) (byte-string? k) (byte-string? v)]}
+   (call asc cb :index-req :index-resp
+         IndexReq->bytes bytes->IndexResp
+         {:bucket b
+          :index k
+          :key v
+          :qtype :eq}))
+  ([asc b k v1 v2 cb]
+   {:pre [(byte-string? b) (byte-string? k) (byte-string? v1) (byte-string? v2)]}
+   (call asc cb :index-req :index-resp
+         IndexReq->bytes bytes->IndexResp
+         {:bucket b
+          :index k
+          :range-min v1
+          :range-max v2
+          :qtype :range})))

--- a/src/clojure/kria/pb/index/secondary/get.clj
+++ b/src/clojure/kria/pb/index/secondary/get.clj
@@ -2,7 +2,7 @@
   (:require
    [kria.conversions :refer [utf8-string<-byte-string
                              byte-string<-utf8-string]]
-   [kria.pb.pair :refer [pb->Pair]])
+   [kria.pb.pair :refer [pb->Pair Pair->pb]])
   (:import
    [com.basho.riak.protobuf
     RiakKvPB$RpbIndexReq
@@ -90,8 +90,8 @@
 (defn pb->IndexResp
   [^RiakKvPB$RpbIndexResp pb]
   (->IndexResp
-   (mapv utf8-string<-byte-string (.getKeys pb))
-   (mapv pb->Pair (.getResults pb))
+   (mapv utf8-string<-byte-string (.getKeysList pb))
+   (mapv pb->Pair (.getResultsList pb))
    (.getContinuation pb)
    (.getDone pb)))
 

--- a/src/clojure/kria/pb/index/secondary/get.clj
+++ b/src/clojure/kria/pb/index/secondary/get.clj
@@ -1,0 +1,101 @@
+(ns kria.pb.index.secondary.get
+  (:require
+   [kria.conversions :refer [utf8-string<-byte-string
+                             byte-string<-utf8-string]]
+   [kria.pb.pair :refer [pb->Pair]])
+  (:import
+   [com.basho.riak.protobuf
+    RiakKvPB$RpbIndexReq
+    RiakKvPB$RpbIndexReq$IndexQueryType
+    RiakKvPB$RpbIndexResp]))
+
+(defrecord IndexReq
+    [bucket          ; required bytes
+     index           ; required bytes
+     qtype           ; enum eq = 0, range = 1
+     key             ; optional bytes see note at https://github.com/basho/riak_pb/blob/develop/src/riak_kv.proto#L173
+     range-min       ; optional bytes
+     range-max       ; optional bytes
+     return-terms    ; optional bool
+     stream          ; optional bool
+     max-results     ; optional uint32
+     continuation    ; optional bytes
+     timeout         ; optional uint32
+     type            ; optional bytes
+     term-regex      ; optional bytes
+     pagination-sort ; optional bool
+     ])
+
+(defn ^RiakKvPB$RpbIndexReq IndexReq->pb
+  [m]
+  (let [{:keys [bucket
+                index
+                qtype
+                key
+                range-min
+                range-max
+                return-terms
+                stream
+                max-results
+                continuation
+                timeout
+                type
+                term-regex
+                pagination-sort]} m
+        b (RiakKvPB$RpbIndexReq/newBuilder)]
+    (when bucket
+      (.setBucket b bucket))
+    (when index
+      (.setIndex b index))
+    (when qtype
+      (.setQtype b (case qtype
+                     :eq (RiakKvPB$RpbIndexReq$IndexQueryType/eq)
+                     :range (RiakKvPB$RpbIndexReq$IndexQueryType/range)
+                     (RiakKvPB$RpbIndexReq$IndexQueryType/eq))))
+    (when key
+      (.setKey b key))
+    (when range-min
+      (.setRangeMin b range-min))
+    (when range-max
+      (.setRangeMax b range-max))
+    (when return-terms
+      (.setReturnTerms b return-terms))
+    (when stream
+      (.setStream b stream))
+    (when max-results
+      (.setMaxResults b max-results))
+    (when continuation
+      (.setContinuation b continuation))
+    (when timeout
+      (.setTimeout b timeout))
+    (when type
+      (.setType b type))
+    (when term-regex
+      (.setTermRegex b term-regex))
+    (when pagination-sort
+      (.setPaginationSort b pagination-sort))
+    (.build b)))
+
+(defn IndexReq->bytes
+  [m]
+  (.toByteArray (IndexReq->pb m)))
+
+(defrecord IndexResp
+    [keys         ; repeated bytes
+     results      ; repeated pair
+     continuation ; optional bytes
+     done         ; optional bool
+     ])
+
+(defn pb->IndexResp
+  [^RiakKvPB$RpbIndexResp pb]
+  (->IndexResp
+   (mapv utf8-string<-byte-string (.getKeys pb))
+   (mapv pb->Pair (.getResults pb))
+   (.getContinuation pb)
+   (.getDone pb)))
+
+(defn bytes->IndexResp
+  [^bytes x]
+  (pb->IndexResp
+   (RiakKvPB$RpbIndexResp/parseFrom x)))

--- a/src/clojure/kria/pb/index/yz/delete.clj
+++ b/src/clojure/kria/pb/index/yz/delete.clj
@@ -1,4 +1,4 @@
-(ns kria.pb.index.delete
+(ns kria.pb.index.yz.delete
   (:require
    [kria.conversions :refer [utf8-string<-byte-string
                              byte-string<-utf8-string]])

--- a/src/clojure/kria/pb/index/yz/get.clj
+++ b/src/clojure/kria/pb/index/yz/get.clj
@@ -1,8 +1,8 @@
-(ns kria.pb.index.get
+(ns kria.pb.index.yz.get
   (:require
    [kria.conversions :refer [utf8-string<-byte-string
                              byte-string<-utf8-string]]
-   [kria.pb.index.index :refer [pb->Index]])
+   [kria.pb.index.yz.index :refer [pb->Index]])
   (:import
    [com.basho.riak.protobuf
     RiakYokozunaPB$RpbYokozunaIndexGetReq

--- a/src/clojure/kria/pb/index/yz/index.clj
+++ b/src/clojure/kria/pb/index/yz/index.clj
@@ -1,4 +1,4 @@
-(ns kria.pb.index.index
+(ns kria.pb.index.yz.index
   (:require
    [kria.conversions :refer [utf8-string<-byte-string
                              byte-string<-utf8-string]])

--- a/src/clojure/kria/pb/index/yz/put.clj
+++ b/src/clojure/kria/pb/index/yz/put.clj
@@ -1,6 +1,6 @@
-(ns kria.pb.index.put
+(ns kria.pb.index.yz.put
   (:require
-   [kria.pb.index.index :refer [Index->pb]])
+   [kria.pb.index.yz.index :refer [Index->pb]])
   (:import
    [com.basho.riak.protobuf
     RiakYokozunaPB$RpbYokozunaIndexPutReq]))

--- a/test/kria/index_test.clj
+++ b/test/kria/index_test.clj
@@ -48,8 +48,13 @@
          (h/cb-fn get-p))
         (let [[asc e a] @get-p
               {:keys [keys]} a]
-          (is (= (count keys)
-                 1))
-          (is (= (first keys) (conv/utf8-string<-byte-string k)))))
+          (if (get (System/getenv) "KRIA_TEST_2I")
+            (testing "index search returns the object (2i enabled)"
+              (is (= (count keys)
+                     1))
+              (is (= (first keys) (conv/utf8-string<-byte-string k))))
+            (testing "index search returns nothing (2i disabled)"
+              (is (= (count keys)
+                     0))))))
 
       (c/disconnect conn))))

--- a/test/kria/index_test.clj
+++ b/test/kria/index_test.clj
@@ -38,23 +38,19 @@
         (o/put conn b k o-val {} (h/cb-fn put-p))
         @put-p)
 
-      (testing "get a value with an index"
-        (i/get-2i
-         conn
-         b
-         (conv/byte-string<-utf8-string "test_bin")
-         (conv/byte-string<-utf8-string "test-idx-val")
-         {}
-         (h/cb-fn get-p))
-        (let [[asc e a] @get-p
-              {:keys [keys]} a]
-          (if (get (System/getenv) "KRIA_TEST_2I")
-            (testing "index search returns the object (2i enabled)"
+      (when (get (System/getenv) "KRIA_TEST_2I")
+          (testing "get a value with an index"
+            (i/get-2i
+             conn
+             b
+             (conv/byte-string<-utf8-string "test_bin")
+             (conv/byte-string<-utf8-string "test-idx-val")
+             {}
+             (h/cb-fn get-p))
+            (let [[asc e a] @get-p
+                  {:keys [keys]} a]
               (is (= (count keys)
                      1))
-              (is (= (first keys) (conv/utf8-string<-byte-string k))))
-            (testing "index search returns nothing (2i disabled)"
-              (is (= (count keys)
-                     0))))))
+              (is (= (first keys) (conv/utf8-string<-byte-string k))))))
 
       (c/disconnect conn))))

--- a/test/kria/index_test.clj
+++ b/test/kria/index_test.clj
@@ -3,7 +3,11 @@
    [clojure.test :refer :all]
    [kria.test-helpers :as h]
    [kria.client :as c]
-   [kria.index :as i]))
+   [kria.index :as i]
+   [kria.object :as o]
+   [kria.pb.pair :refer [Pair->pb]]
+   [kria.conversions :as conv]
+   ))
 
 (deftest put-1-get-1-test
   (testing "put 1, get 1"
@@ -18,4 +22,34 @@
       (i/get conn idx (h/cb-fn p2))
       @p2
       (is (h/index-ready? conn idx))
+      (c/disconnect conn))))
+
+(deftest secondary-index-test
+  (testing "storing and searching for an object with secondary indices."
+    (let [conn (h/connect)
+          b (h/rand-bucket)
+
+          k (h/rand-key)
+          o-val (assoc (h/rand-value) :indexes [{:key "test_bin" :value "test-idx-val"}])
+
+          put-p (promise)
+          get-p (promise)]
+      (testing "store a value with an index"
+        (o/put conn b k o-val {} (h/cb-fn put-p))
+        @put-p)
+
+      (testing "get a value with an index"
+        (i/get-2i
+         conn
+         b
+         (conv/byte-string<-utf8-string "test_bin")
+         (conv/byte-string<-utf8-string "test-idx-val")
+         {}
+         (h/cb-fn get-p))
+        (let [[asc e a] @get-p
+              {:keys [keys]} a]
+          (is (= (count keys)
+                 1))
+          (is (= (first keys) (conv/utf8-string<-byte-string k)))))
+
       (c/disconnect conn))))

--- a/test/riak-setup.sh
+++ b/test/riak-setup.sh
@@ -14,6 +14,7 @@ setup_riak_bucket_type_counter () {
 setup () {
   setup_riak_bucket_type_counter
   setup_riak_bucket_type_set
+  echo 'If your storage backend supports secondary indexes, set KRIA_TEST_2I to true before testing.'
 }
 
 setup


### PR DESCRIPTION
Adds basic functionality to query secondary indexes.

* Namespaced existing yz index stuff to disambiguate, put this stuff in at `index.secondary`
* Added `kria.index/get-2i` api fn. It has two arities, the first takes an index and a val and does an equality search, the second takes and index and two vals and does a range search.
* Added a simple test for binary index.

### Issues
* Only binary indexes are supported, as I can't figure out how to send integer index info on objects. The `RiakPB$RpbPair` builder seems to expect binary keys *and* values.
* Index keys MUST have `_bin` appended, or Riak will barf in a pretty spectacular way (uncaught exception on the server). I didn't add any validation/assertion for this, as this seemed outside the scope of the library.